### PR TITLE
Clients time hostname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/lib/invoca/metrics/client.rb
+++ b/lib/invoca/metrics/client.rb
@@ -77,7 +77,8 @@ module Invoca
         start = Time.now
         result = yield
         length_of_time = ((Time.now - start) * MILLISECONDS_IN_SECOND).round
-        timing(stat, length_of_time, sample_rate)
+        name_and_type = [stat, "timer", @server_name].join(STATSD_METRICS_SEPARATOR)
+        timing(name_and_type, length_of_time, sample_rate)
         [result, length_of_time]
       end
 


### PR DESCRIPTION
All the other client functions automatically append the hostname to the metric name except time.  Time is only used in one place currently that I could find (pnapi/remote_manager) 

The sidekiq-pro statsd interface uses this function and without the unique hostname causes the metrics to name conflict in graphite. 

@primiti @ColinDKelley 