### PR TITLE
Use presence instead of house-defined nonblank?

### DIFF
--- a/lib/invoca/common.rb
+++ b/lib/invoca/common.rb
@@ -5,6 +5,7 @@
 # see https://rails.lighthouseapp.com/projects/8994/tickets/3620-objectnonblank-analogous-to-rubys-numericnonzero
 class Object
   def nonblank?
+    warn 'Object#nonblank? is deprecated, please use Object#presence instead'
     self if !blank?
   end
 end

--- a/lib/invoca/metrics/client.rb
+++ b/lib/invoca/metrics/client.rb
@@ -21,7 +21,7 @@ module Invoca
         @sub_server_name = sub_server_name
 
         super(@hostname, @port)
-        self.namespace = [@cluster_name, @service_name].compact.join(STATSD_METRICS_SEPARATOR).nonblank?
+        self.namespace = [@cluster_name, @service_name].compact.join(STATSD_METRICS_SEPARATOR).presence
       end
 
       def gauge(name, value)
@@ -53,7 +53,7 @@ module Invoca
       end
 
       def timer(name, milliseconds = nil, &block)
-        name.nonblank? or raise ArgumentError, "Must specify a metric name."
+        name.presence or raise ArgumentError, "Must specify a metric name."
         (!milliseconds.nil? ^ block_given?) or raise ArgumentError, "Must pass exactly one of milliseconds or block."
         name_and_type = [name, "timer", @server_name].join(STATSD_METRICS_SEPARATOR)
 
@@ -84,7 +84,7 @@ module Invoca
     protected
 
       def metric_args(name, value, stat_type)
-        name.nonblank? or raise ArgumentError, "Must specify a metric name."
+        name.presence or raise ArgumentError, "Must specify a metric name."
         extended_name = [name, stat_type, @server_name, @sub_server_name].compact.join(STATSD_METRICS_SEPARATOR)
         if value
           [extended_name, value]

--- a/lib/invoca/metrics/client.rb
+++ b/lib/invoca/metrics/client.rb
@@ -53,7 +53,7 @@ module Invoca
       end
 
       def timer(name, milliseconds = nil, &block)
-        name.presence or raise ArgumentError, "Must specify a metric name."
+        name.present? or raise ArgumentError, "Must specify a metric name."
         (!milliseconds.nil? ^ block_given?) or raise ArgumentError, "Must pass exactly one of milliseconds or block."
         name_and_type = [name, "timer", @server_name].join(STATSD_METRICS_SEPARATOR)
 
@@ -84,7 +84,7 @@ module Invoca
     protected
 
       def metric_args(name, value, stat_type)
-        name.presence or raise ArgumentError, "Must specify a metric name."
+        name.present? or raise ArgumentError, "Must specify a metric name."
         extended_name = [name, stat_type, @server_name, @sub_server_name].compact.join(STATSD_METRICS_SEPARATOR)
         if value
           [extended_name, value]

--- a/lib/invoca/metrics/version.rb
+++ b/lib/invoca/metrics/version.rb
@@ -1,5 +1,5 @@
 module Invoca
   module Metrics
-    VERSION = "1.0.2"
+    VERSION = "1.0.3"
   end
 end


### PR DESCRIPTION
@HParker 
CR to deprecate nonblank in this gem as well. Do you think we can go ahead and just take out the definition because it is such a small repo? My thinking was that it's not that much extra work to deprecate one sprint and remove the next. Although it is a little fussy to update tertiary version twice - once for deprecate and once for removal.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/invoca/invoca-metrics/3)
<!-- Reviewable:end -->
