### PR TITLE
TECH-3082 server group option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Or install it yourself as:
 
 ## Setup
 
+### Default Setup
+
 Add the following code to your application...
 
     require 'invoca/metrics'
@@ -26,19 +28,48 @@ Add the following code to your application...
     Invoca::Metrics.server_name     = Socket.gethostname
     Invoca::Metrics.cluster_name    = "production"
     Invoca::Metrics.sub_server_name = "worker_process_1"
+    Invoca::Metrics.statsd_host     = "255.0.0.123"
+    Invoca::Metrics.statsd_port     = 200
 
-Out of the four settings above, only `service_name` is required.  The others are optional.
+Out of the settings above, only `service_name` is required.  The others are optional.
 
-### server_name vs server_group
+### Multi Configuration
 
-The default `:server_identifier` is `:server_name`. Set `server_identifier` as `:server_group` in order to defer to using a more generic label than the supplied `server_name`
+In order to configure multiple configurations, supply a `config` hash with additional settings.
 
-Note: `sub_server_name` and `cluster_name` are not affected
+    Invoca::Metrics.config = {
+      deployment_group: {
+        server_name: "deployment"
+        statsd_host: "255.0.0.456",
+        statsd_port: 300
+      },
+      region: {
+        server_name:     "region_name"
+        statsd_host:     "255.0.0.789",
+        statsd_port:     400,
+        sub_server_name: nil
+        cluster_name:    nil
+      }
+    }
 
-    Invoca::Metrics.server_group             = "my_group"
-    Invoca::Metrics.server_identifier        = :server_group
-    Invoca::Metrics.server_group_statsd_host = "127.0.0.1"
-    Invoca::Metrics.server_group_statsd_port = 1
+The settings (`[service_name, server_name, cluster_name, sub_server_name, statsd_host, statsd_port]`) directly set on Invoca::Metrics will be the default values supplied if the individual identifier config does not supply the option.
+It's highly suggested that each configuration has its own `statsd_host` and `statsd_port` along with unique naming since writing the same metric from one statsd node could be overwritten by the same metric from a separate node.
+
+In order to set a configuration as the default, set the configuration key as `default_identifier`.
+
+    Invoca::Metrics.default_identifier = :deployment_group
+
+Any keys missing from the `default_identifier` config will by default have the values from the keys set directly on `Invoca::Metrics`.
+
+The full set of default values for the above example would then be
+
+    service_name:    "my_event_worker"
+    cluster_name:    "production"
+    sub_server_name: "worker_process_1"
+    server_name:     "deployment"
+    statsd_host:     "255.0.0.456",
+    statsd_port:     300
+
 
 ## Usage
 
@@ -49,9 +80,13 @@ Mixin the Source module:
       ...
     end
 
-Then call any method from `Invoca::Metrics::Client` via the `metrics` member:
+Then call any method from `Invoca::Metrics::Client` via the `metrics` member (the client will be configured with the default config):
 
     metrics.timer("some_process/execution_time", time_in_ms)
+
+You can also request a specific config identifier by calling `metrics_for(identifier: identifier_key)`
+
+    metrics_for(identifier: :region).count("region_upload.success")
 
 Additional examples of using the gem can be found in the file: test/integration/metrics_gem_tester.rb
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Add the following code to your application...
 
 Out of the four settings above, only `service_name` is required.  The others are optional.
 
+### server_name vs server_group
+
+The default `:server_identifier` is `:server_name`. Set `server_identifier` as `:server_group` in order to defer to using a more generic label than the supplied `server_name`
+
+Note: `sub_server_name` and `cluster_name` are not affected
+
+    Invoca::Metrics.server_group             = "my_group"
+    Invoca::Metrics.server_identifier        = :server_group
+    Invoca::Metrics.server_group_statsd_host = "127.0.0.1"
+    Invoca::Metrics.server_group_statsd_port = 1
+
 ## Usage
 
 Mixin the Source module:

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ In order to configure multiple configurations, supply a `config` hash with addit
       }
     }
 
-The settings (`[service_name, server_name, cluster_name, sub_server_name, statsd_host, statsd_port]`) directly set on Invoca::Metrics will be the default values supplied if the individual identifier config does not supply the option.
+The settings (`[service_name, server_name, cluster_name, sub_server_name, statsd_host, statsd_port]`) directly set on `Invoca::Metrics` will be the default values supplied if the individual configuration does not supply the option.
 It's highly suggested that each configuration has its own `statsd_host` and `statsd_port` along with unique naming since writing the same metric from one statsd node could be overwritten by the same metric from a separate node.
 
-In order to set a configuration as the default, set the configuration key as `default_identifier`.
+In order to set a configuration as the default, set the configuration key as `default_config_key`.
 
-    Invoca::Metrics.default_identifier = :deployment_group
+    Invoca::Metrics.default_config_key = :deployment_group
 
-Any keys missing from the `default_identifier` config will by default have the values from the keys set directly on `Invoca::Metrics`.
+Any keys missing from the `default_config_key` config will by default have the values from the keys set directly on `Invoca::Metrics`.
 
 The full set of default values for the above example would then be
 
@@ -84,9 +84,9 @@ Then call any method from `Invoca::Metrics::Client` via the `metrics` member (th
 
     metrics.timer("some_process/execution_time", time_in_ms)
 
-You can also request a specific config identifier by calling `metrics_for(identifier: identifier_key)`
+You can also request a specific configuration by calling `metrics_for(config_key: configuration_key)`
 
-    metrics_for(identifier: :region).count("region_upload.success")
+    metrics_for(config_key: :region).count("region_upload.success")
 
 Additional examples of using the gem can be found in the file: test/integration/metrics_gem_tester.rb
 

--- a/lib/invoca/metrics.rb
+++ b/lib/invoca/metrics.rb
@@ -13,7 +13,7 @@ module Invoca
     CONFIG_FIELDS = [:service_name, :server_name, :sub_server_name, :cluster_name, :statsd_host, :statsd_port].freeze
 
     class << self
-      attr_accessor *CONFIG_FIELDS, :default_config_key
+      attr_accessor(*CONFIG_FIELDS, :default_config_key)
 
       def service_name
         @service_name or raise ArgumentError, "You must assign a value to Invoca::Metrics.service_name"

--- a/lib/invoca/metrics.rb
+++ b/lib/invoca/metrics.rb
@@ -10,15 +10,35 @@ require "invoca/metrics/batch"
 
 module Invoca
   module Metrics
+    @server_identifier = :server_name
 
     class << self
-      attr_accessor :service_name, :server_name, :sub_server_name, :cluster_name, :statsd_host, :statsd_port
+      attr_accessor :service_name, :server_name, :server_group, :sub_server_name, :cluster_name, :server_identifier,
+                    :statsd_host, :statsd_port, :server_group_statsd_host, :server_group_statsd_port
 
       def service_name
         if @service_name.nil?
           raise ArgumentError, "You must assign a value to Invoca::Metrics.service_name"
         end
         @service_name
+      end
+
+      def host
+        values_by_server_identifier(statsd_host, server_group_statsd_host)[server_identifier]
+      end
+
+      def port
+        values_by_server_identifier(statsd_port, server_group_statsd_port)[server_identifier]
+      end
+
+      def server_label
+        values_by_server_identifier(server_name, server_group)[server_identifier]
+      end
+
+      private
+
+      def values_by_server_identifier(server_name_value, server_group_value)
+        { server_name: server_name_value, server_group: server_group_value }
       end
     end
 

--- a/lib/invoca/metrics.rb
+++ b/lib/invoca/metrics.rb
@@ -10,12 +10,10 @@ require "invoca/metrics/batch"
 
 module Invoca
   module Metrics
-    @server_identifier = :server_name
-
     class << self
       attr_accessor :service_name, :server_name, :sub_server_name, :cluster_name, :statsd_host, :statsd_port
 
-      attr_accessor :default_identifier
+      attr_accessor :default_config_key
       attr_writer   :config
 
       def service_name
@@ -34,7 +32,7 @@ module Invoca
           statsd_host:     Invoca::Metrics.statsd_host,
           statsd_port:     Invoca::Metrics.statsd_port,
           sub_server_name: Invoca::Metrics.sub_server_name
-        }.merge(config[default_identifier] || {})
+        }.merge(config[default_config_key] || {})
       end
     end
 
@@ -45,15 +43,15 @@ module Invoca
 
       module ClassMethods
         def metrics
-          @metrics ||= metrics_for(identifier: Invoca::Metrics.default_identifier)
+          @metrics ||= metrics_for(config_key: Invoca::Metrics.default_config_key)
         end
 
-        def metrics_for(identifier:)
+        def metrics_for(config_key:)
           @metrics_for ||= {}
-          @metrics_for[identifier] ||=
+          @metrics_for[config_key] ||=
             begin
-              identifier_metrics_config = Invoca::Metrics.config[identifier] || {}
-              Client.metrics(Invoca::Metrics.default_client_config.merge(identifier_metrics_config))
+              metrics_config = Invoca::Metrics.config[config_key] || {}
+              Client.metrics(Invoca::Metrics.default_client_config.merge(metrics_config))
             end
         end
       end
@@ -62,8 +60,8 @@ module Invoca
         self.class.metrics
       end
 
-      def metrics_for(identifier:)
-        self.class.metrics_for(identifier: identifier)
+      def metrics_for(config_key:)
+        self.class.metrics_for(config_key: config_key)
       end
     end
   end

--- a/lib/invoca/metrics.rb
+++ b/lib/invoca/metrics.rb
@@ -10,11 +10,10 @@ require "invoca/metrics/batch"
 
 module Invoca
   module Metrics
-    class << self
-      attr_accessor :service_name, :server_name, :sub_server_name, :cluster_name, :statsd_host, :statsd_port
+    CONFIG_FIELDS = [:service_name, :server_name, :sub_server_name, :cluster_name, :statsd_host, :statsd_port].freeze
 
-      attr_accessor :default_config_key
-      attr_writer   :config
+    class << self
+      attr_accessor *CONFIG_FIELDS, :default_config_key
 
       def service_name
         @service_name or raise ArgumentError, "You must assign a value to Invoca::Metrics.service_name"
@@ -22,6 +21,11 @@ module Invoca
 
       def config
         @config ||= {}
+      end
+
+      def config=(config_hash)
+        config_valid?(config_hash) or raise ArgumentError, "Invalid config #{config_hash}. Allowed fields for config key: #{CONFIG_FIELDS}."
+        @config = config_hash
       end
 
       def default_client_config
@@ -33,6 +37,12 @@ module Invoca
           statsd_port:     Invoca::Metrics.statsd_port,
           sub_server_name: Invoca::Metrics.sub_server_name
         }.merge(config[default_config_key] || {})
+      end
+
+      private
+
+      def config_valid?(config_hash)
+        config_hash.nil? || config_hash.all? { |_config_key, config_key_hash| (config_key_hash.keys - CONFIG_FIELDS).empty?  }
       end
     end
 

--- a/lib/invoca/metrics/batch.rb
+++ b/lib/invoca/metrics/batch.rb
@@ -5,12 +5,12 @@ module Invoca
 
       # @param [Statsd] requires a configured Client instance
       def initialize(client)
-        @client = client
-        @server_name = @client.server_name
+        @client          = client
+        @server_label    = @client.server_label
         @sub_server_name = @client.sub_server_name
-        @batch_size = @client.batch_size
-        self.namespace = @client.namespace
-        @backlog = []
+        @batch_size      = @client.batch_size
+        self.namespace   = @client.namespace
+        @backlog         = []
       end
 
       # @yields [Batch] yields itself

--- a/lib/invoca/metrics/client.rb
+++ b/lib/invoca/metrics/client.rb
@@ -92,8 +92,7 @@ module Invoca
                     cluster_name:    Invoca::Metrics.cluster_name,
                     service_name:    Invoca::Metrics.service_name,
                     server_name:     Invoca::Metrics.server_name,
-                    sub_server_name: Invoca::Metrics.sub_server_name,
-                    **_params)
+                    sub_server_name: Invoca::Metrics.sub_server_name)
           new(statsd_host || Client::STATSD_DEFAULT_HOSTNAME,
               statsd_port || Client::STATSD_DEFAULT_PORT,
               cluster_name,

--- a/lib/invoca/metrics/client.rb
+++ b/lib/invoca/metrics/client.rb
@@ -9,15 +9,15 @@ module Invoca
 
       MILLISECONDS_IN_SECOND = 1000
 
-      attr_reader :hostname, :port, :statsd_prefix, :server_name, :sub_server_name
+      attr_reader :hostname, :port, :statsd_prefix, :server_label, :sub_server_name
 
-      def initialize(hostname, port, cluster_name, service_name, server_name, sub_server_name)
+      def initialize(hostname, port, cluster_name, service_name, server_label, sub_server_name)
 
-        @hostname = hostname
-        @port = port
-        @cluster_name = cluster_name
-        @service_name = service_name
-        @server_name =  server_name
+        @hostname        = hostname
+        @port            = port
+        @cluster_name    = cluster_name
+        @service_name    = service_name
+        @server_label    =  server_label
         @sub_server_name = sub_server_name
 
         super(@hostname, @port)
@@ -55,7 +55,7 @@ module Invoca
       def timer(name, milliseconds = nil, &block)
         name.present? or raise ArgumentError, "Must specify a metric name."
         (!milliseconds.nil? ^ block_given?) or raise ArgumentError, "Must pass exactly one of milliseconds or block."
-        name_and_type = [name, "timer", @server_name].join(STATSD_METRICS_SEPARATOR)
+        name_and_type = [name, "timer", @server_label].join(STATSD_METRICS_SEPARATOR)
 
         if milliseconds.nil?
           result, block_time = time(name_and_type, &block)
@@ -82,18 +82,21 @@ module Invoca
       end
 
       class << self
-
         def metrics
-          new(Invoca::Metrics.statsd_host || Client::STATSD_DEFAULT_HOSTNAME, Invoca::Metrics.statsd_port || Client::STATSD_DEFAULT_PORT, Invoca::Metrics.cluster_name, Invoca::Metrics.service_name, Invoca::Metrics.server_name, Invoca::Metrics.sub_server_name)
+          new(Invoca::Metrics.host || Client::STATSD_DEFAULT_HOSTNAME,
+              Invoca::Metrics.port || Client::STATSD_DEFAULT_PORT,
+              Invoca::Metrics.cluster_name,
+              Invoca::Metrics.service_name,
+              Invoca::Metrics.server_label,
+              Invoca::Metrics.sub_server_name)
         end
-
       end
 
     protected
 
       def metric_args(name, value, stat_type)
         name.present? or raise ArgumentError, "Must specify a metric name."
-        extended_name = [name, stat_type, @server_name, @sub_server_name].compact.join(STATSD_METRICS_SEPARATOR)
+        extended_name = [name, stat_type, @server_label, @sub_server_name].compact.join(STATSD_METRICS_SEPARATOR)
         if value
           [extended_name, value]
         else

--- a/lib/invoca/metrics/client.rb
+++ b/lib/invoca/metrics/client.rb
@@ -17,7 +17,7 @@ module Invoca
         @port            = port
         @cluster_name    = cluster_name
         @service_name    = service_name
-        @server_label    =  server_label
+        @server_label    = server_label
         @sub_server_name = sub_server_name
 
         super(@hostname, @port)

--- a/lib/invoca/metrics/client.rb
+++ b/lib/invoca/metrics/client.rb
@@ -86,13 +86,20 @@ module Invoca
       end
 
       class << self
-        def metrics
-          new(Invoca::Metrics.host || Client::STATSD_DEFAULT_HOSTNAME,
-              Invoca::Metrics.port || Client::STATSD_DEFAULT_PORT,
-              Invoca::Metrics.cluster_name,
-              Invoca::Metrics.service_name,
-              Invoca::Metrics.server_label,
-              Invoca::Metrics.sub_server_name)
+        # Default values are required for backwards compatibility
+        def metrics(statsd_host:     Invoca::Metrics.statsd_host,
+                    statsd_port:     Invoca::Metrics.statsd_port,
+                    cluster_name:    Invoca::Metrics.cluster_name,
+                    service_name:    Invoca::Metrics.service_name,
+                    server_name:     Invoca::Metrics.server_name,
+                    sub_server_name: Invoca::Metrics.sub_server_name,
+                    **_)
+          new(statsd_host || Client::STATSD_DEFAULT_HOSTNAME,
+              statsd_port || Client::STATSD_DEFAULT_PORT,
+              cluster_name,
+              service_name,
+              server_name,
+              sub_server_name)
         end
       end
 

--- a/lib/invoca/metrics/client.rb
+++ b/lib/invoca/metrics/client.rb
@@ -93,7 +93,7 @@ module Invoca
                     service_name:    Invoca::Metrics.service_name,
                     server_name:     Invoca::Metrics.server_name,
                     sub_server_name: Invoca::Metrics.sub_server_name,
-                    **_)
+                    **_params)
           new(statsd_host || Client::STATSD_DEFAULT_HOSTNAME,
               statsd_port || Client::STATSD_DEFAULT_PORT,
               cluster_name,

--- a/lib/invoca/metrics/client.rb
+++ b/lib/invoca/metrics/client.rb
@@ -24,6 +24,10 @@ module Invoca
         self.namespace = [@cluster_name, @service_name].compact.join(STATSD_METRICS_SEPARATOR).presence
       end
 
+      def server_name # For backwards compatibility
+        server_label
+      end
+
       def gauge(name, value)
         if args = metric_args(name, value, "gauge")
           super(*args)

--- a/lib/invoca/metrics/version.rb
+++ b/lib/invoca/metrics/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Invoca
   module Metrics
     VERSION = "1.2.0"

--- a/lib/invoca/metrics/version.rb
+++ b/lib/invoca/metrics/version.rb
@@ -1,5 +1,5 @@
 module Invoca
   module Metrics
-    VERSION = "1.1.0"
+    VERSION = "1.2.0"
   end
 end

--- a/test/helpers/metrics/metrics_test_helpers.rb
+++ b/test/helpers/metrics/metrics_test_helpers.rb
@@ -4,17 +4,33 @@ module MetricsTestHelpers
   include TrackSentMessage
 
   def stub_metrics_as_production_unicorn
-    stub_metrics("prod-fe1", nil, "unicorn")
+    stub_metrics(server_name: "prod-fe1", cluster_name: nil, service_name: "unicorn")
   end
 
   def stub_metrics_as_staging_unicorn
-    stub_metrics("staging-full-fe1", "staging", "unicorn")
+    stub_metrics(server_name: "staging-full-fe1", cluster_name: "staging", service_name: "unicorn")
   end
 
-  def stub_metrics(server_name, cluster_name, service_name)
-    Invoca::Metrics.server_name = server_name
-    Invoca::Metrics.cluster_name = cluster_name
-    Invoca::Metrics.service_name = service_name
+  def stub_metrics(service_name:             nil,
+                   server_name:              nil,
+                   cluster_name:             nil,
+                   server_identifier:        :server_name,
+                   statsd_host:              nil,
+                   statsd_port:              nil,
+                   server_group:             nil,
+                   server_group_statsd_host: nil,
+                   server_group_statsd_port: nil,
+                   sub_server_name:          nil)
+    Invoca::Metrics.server_name              = server_name
+    Invoca::Metrics.cluster_name             = cluster_name
+    Invoca::Metrics.service_name             = service_name
+    Invoca::Metrics.server_identifier        = server_identifier
+    Invoca::Metrics.statsd_host              = statsd_host
+    Invoca::Metrics.statsd_port              = statsd_port
+    Invoca::Metrics.server_group             = server_group
+    Invoca::Metrics.server_group_statsd_host = server_group_statsd_host
+    Invoca::Metrics.server_group_statsd_port = server_group_statsd_port
+    Invoca::Metrics.sub_server_name          = sub_server_name
   end
 
   def metrics_client_with_message_tracking

--- a/test/helpers/metrics/metrics_test_helpers.rb
+++ b/test/helpers/metrics/metrics_test_helpers.rb
@@ -18,7 +18,7 @@ module MetricsTestHelpers
                    statsd_port:        nil,
                    sub_server_name:    nil,
                    config:             nil,
-                   default_identifier: nil)
+                   default_config_key: nil)
     Invoca::Metrics.server_name        = server_name
     Invoca::Metrics.cluster_name       = cluster_name
     Invoca::Metrics.service_name       = service_name
@@ -26,7 +26,7 @@ module MetricsTestHelpers
     Invoca::Metrics.statsd_port        = statsd_port
     Invoca::Metrics.sub_server_name    = sub_server_name
     Invoca::Metrics.config             = config
-    Invoca::Metrics.default_identifier = default_identifier
+    Invoca::Metrics.default_config_key = default_config_key
   end
 
   def metrics_client_with_message_tracking

--- a/test/helpers/metrics/metrics_test_helpers.rb
+++ b/test/helpers/metrics/metrics_test_helpers.rb
@@ -11,26 +11,22 @@ module MetricsTestHelpers
     stub_metrics(server_name: "staging-full-fe1", cluster_name: "staging", service_name: "unicorn")
   end
 
-  def stub_metrics(service_name:             nil,
-                   server_name:              nil,
-                   cluster_name:             nil,
-                   server_identifier:        :server_name,
-                   statsd_host:              nil,
-                   statsd_port:              nil,
-                   server_group:             nil,
-                   server_group_statsd_host: nil,
-                   server_group_statsd_port: nil,
-                   sub_server_name:          nil)
-    Invoca::Metrics.server_name              = server_name
-    Invoca::Metrics.cluster_name             = cluster_name
-    Invoca::Metrics.service_name             = service_name
-    Invoca::Metrics.server_identifier        = server_identifier
-    Invoca::Metrics.statsd_host              = statsd_host
-    Invoca::Metrics.statsd_port              = statsd_port
-    Invoca::Metrics.server_group             = server_group
-    Invoca::Metrics.server_group_statsd_host = server_group_statsd_host
-    Invoca::Metrics.server_group_statsd_port = server_group_statsd_port
-    Invoca::Metrics.sub_server_name          = sub_server_name
+  def stub_metrics(service_name:       nil,
+                   server_name:        nil,
+                   cluster_name:       nil,
+                   statsd_host:        nil,
+                   statsd_port:        nil,
+                   sub_server_name:    nil,
+                   config:             nil,
+                   default_identifier: nil)
+    Invoca::Metrics.server_name        = server_name
+    Invoca::Metrics.cluster_name       = cluster_name
+    Invoca::Metrics.service_name       = service_name
+    Invoca::Metrics.statsd_host        = statsd_host
+    Invoca::Metrics.statsd_port        = statsd_port
+    Invoca::Metrics.sub_server_name    = sub_server_name
+    Invoca::Metrics.config             = config
+    Invoca::Metrics.default_identifier = default_identifier
   end
 
   def metrics_client_with_message_tracking

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,8 @@ require 'shoulda'
 
 require 'invoca/metrics'
 
+ActiveSupport.test_order = :random
+
 class Time
   cattr_reader :now_override
 

--- a/test/unit/invoca/metrics/metrics_client_test.rb
+++ b/test/unit/invoca/metrics/metrics_client_test.rb
@@ -40,6 +40,15 @@ describe Invoca::Metrics::Client do
     end
   end
 
+  context "#server_name" do
+    should "return server_label for backwards compatibility" do
+      stub_metrics_as_production_unicorn
+      metrics_client = Invoca::Metrics::Client.metrics
+      assert_equal metrics_client.server_name, metrics_client.server_label
+      assert_equal "prod-fe1", metrics_client.server_name
+    end
+  end
+
   context "reporting to statsd" do
 
     context "in the production environment" do

--- a/test/unit/invoca/metrics/metrics_client_test.rb
+++ b/test/unit/invoca/metrics/metrics_client_test.rb
@@ -38,6 +38,14 @@ describe Invoca::Metrics::Client do
       assert_equal "127.0.0.10", metrics_client.hostname
       assert_equal 1234,         metrics_client.port
     end
+
+    should "construct with given args along with default args" do
+      Invoca::Metrics.statsd_host = "127.0.0.10"
+      Invoca::Metrics.statsd_port = 1234
+      metrics_client = Invoca::Metrics::Client.metrics(statsd_host: "127.0.0.255", statsd_port: 5678)
+      assert_equal "127.0.0.255", metrics_client.hostname
+      assert_equal 5678,          metrics_client.port
+    end
   end
 
   context "#server_name" do

--- a/test/unit/invoca/metrics/metrics_source_test.rb
+++ b/test/unit/invoca/metrics/metrics_source_test.rb
@@ -71,11 +71,11 @@ describe Invoca::Metrics::Source do
             statsd_host: "255.0.0.456"
           }
         }
-        Invoca::Metrics.default_identifier = :deploy_group
+        Invoca::Metrics.default_config_key = :deploy_group
       end
 
       context "#metrics" do
-        should "return metrics client for default identifier" do
+        should "return metrics client for default_config_key" do
           metrics_client = @metric_tester.metrics
           assert_equal "default_sub_server_name", metrics_client.sub_server_name
           assert_equal "255.0.0.123", metrics_client.hostname
@@ -83,8 +83,8 @@ describe Invoca::Metrics::Source do
       end
 
       context "#metrics_for" do
-        should "return metrics client for given identifier" do
-          metrics_client = @metric_tester.metrics_for(identifier: :region)
+        should "return metrics client for given config_key" do
+          metrics_client = @metric_tester.metrics_for(config_key: :region)
           assert_equal "default_sub_server_name", metrics_client.sub_server_name
           assert_equal "255.0.0.456", metrics_client.hostname
         end

--- a/test/unit/invoca/metrics/metrics_source_test.rb
+++ b/test/unit/invoca/metrics/metrics_source_test.rb
@@ -13,7 +13,8 @@ describe Invoca::Metrics::Source do
 
     class << self
       def clear_metrics
-        @metrics = nil
+        @metrics     = nil
+        @metrics_for = nil
       end
     end
 

--- a/test/unit/invoca/metrics_test.rb
+++ b/test/unit/invoca/metrics_test.rb
@@ -27,12 +27,13 @@ describe Invoca::Metrics do
       }
     end
 
-    should "return default config values when no default identifier is set" do
+    should "return default config values when no default_config_key is set" do
       stub_metrics(@default_values)
+      assert_nil Invoca::Metrics.default_config_key
       assert_equal @default_values, Invoca::Metrics.default_client_config
     end
 
-    should "return default config values merged with default identifier config" do
+    should "return class default values merged with default_config_key config" do
       stub_metrics(@default_values)
       Invoca::Metrics.config = {
         deployment_group: {
@@ -41,7 +42,7 @@ describe Invoca::Metrics do
           statsd_port: 80,
         }
       }
-      Invoca::Metrics.default_identifier = :deployment_group
+      Invoca::Metrics.default_config_key = :deployment_group
       expected_client_config = @default_values.merge(server_name: "primary", statsd_host: "127.0.0.100", statsd_port: 80)
       assert_equal expected_client_config, Invoca::Metrics.default_client_config
     end

--- a/test/unit/invoca/metrics_test.rb
+++ b/test/unit/invoca/metrics_test.rb
@@ -13,6 +13,22 @@ describe Invoca::Metrics do
       Invoca::Metrics.config = nil
       assert_equal({}, Invoca::Metrics.config)
     end
+
+    should "raise an argument error if a config is given with an invalid key" do
+      expected_allowed_keys = [:service_name, :server_name, :sub_server_name, :cluster_name, :statsd_host, :statsd_port]
+      assert_raises(ArgumentError, /Invalid config.*Allowed fields for config key: #{expected_allowed_keys}/) do
+        Invoca::Metrics.config = {
+          deployment_group: {
+            service_name: "Valid deployment group service name key",
+            server_name: "Valid deployment group server name key"
+          },
+          region: {
+            service_name: "Valid region service name key",
+            invalid_key: "Invalid region key"
+          }
+        }
+      end
+    end
   end
 
   context ".default_client_config" do

--- a/test/unit/invoca/metrics_test.rb
+++ b/test/unit/invoca/metrics_test.rb
@@ -1,10 +1,75 @@
 require File.expand_path('../../../test_helper',  __FILE__)
 
 describe Invoca::Metrics do
+  include MetricsTestHelpers
 
   should "raise an exception if service name is not defined" do
     Invoca::Metrics.service_name = nil
     assert_raises(ArgumentError) { Invoca::Metrics.service_name }
   end
 
+  context "ClassMethods" do
+    setup do
+      stub_metrics(service_name:             "my_service",
+                   server_identifier:        :server_name,
+                   server_name:              "my_server",
+                   statsd_host:              "127.0.0.1",
+                   statsd_port:              1,
+                   server_group:             "my_group",
+                   server_group_statsd_host: "127.0.0.2",
+                   server_group_statsd_port: 2,
+                   sub_server_name:          "my_sub_server")
+    end
+
+    context ".host" do
+      should "return statsd_host when server_identifier is :server_name" do
+        Invoca::Metrics.server_identifier = :server_name
+        assert_equal "127.0.0.1", Invoca::Metrics.host
+      end
+
+      should "return server_group_statsd_host when server_identifier is :server_group" do
+        Invoca::Metrics.server_identifier = :server_group
+        assert_equal "127.0.0.2", Invoca::Metrics.host
+      end
+
+      should "return nil when server_identifier doesn't have a match" do
+        Invoca::Metrics.server_identifier = :other
+        assert_nil Invoca::Metrics.host
+      end
+    end
+
+    context ".port" do
+      should "return statsd_port when server_identifier is :server_name" do
+        Invoca::Metrics.server_identifier = :server_name
+        assert_equal 1, Invoca::Metrics.port
+      end
+
+      should "return server_group_statsd_port when server_identifier is :server_group" do
+        Invoca::Metrics.server_identifier = :server_group
+        assert_equal 2, Invoca::Metrics.port
+      end
+
+      should "return nil when server_identifier doesn't have a match" do
+        Invoca::Metrics.server_identifier = :other
+        assert_nil Invoca::Metrics.port
+      end
+    end
+
+    context ".server_label" do
+      should "return server_name when server_identifier is :server_name" do
+        Invoca::Metrics.server_identifier = :server_name
+        assert_equal "my_server", Invoca::Metrics.server_label
+      end
+
+      should "return server_group when server_identifier is :server_group" do
+        Invoca::Metrics.server_identifier = :server_group
+        assert_equal "my_group", Invoca::Metrics.server_label
+      end
+
+      should "return nil when server_identifier doesn't have a match" do
+        Invoca::Metrics.server_identifier = :other
+        assert_nil Invoca::Metrics.server_label
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Server Group Class Variables
These class variables were added to `Invoca::Metrics`.
- `server_group`
- `server_identifier` (default is `:server_name`)
- `server_group_statsd_host`
- `server_group_statsd_port`

## Additional Details
- In `Invoca::Metrics::Client` and `Invoca::Metrics::Batch` the instance variable `@server_name` was renamed to `@server_label` to indicate it could be `server_name` or `server_group` depending on the server_identifier.
- This should be backwards compatible since `server_identifier` is initialized by default in `Invoca::Metrics` to `:server_name`.
- I refactored the main `stub_metrics` method in the test helper to `nil` out all fields that aren't specified by default because I found that existing tests would fail inconsistently (because the test order is random) since class variables that are set persist between tests.
- Also got rid of the ActiveSupport test order warning by explicitly setting it to `:random` in the test helper.