### PR TITLE
TECH-3175 frontend deploy group statsd

### DIFF
--- a/lib/invoca/metrics/client.rb
+++ b/lib/invoca/metrics/client.rb
@@ -87,12 +87,12 @@ module Invoca
 
       class << self
         # Default values are required for backwards compatibility
-        def metrics(statsd_host:     Invoca::Metrics.statsd_host,
-                    statsd_port:     Invoca::Metrics.statsd_port,
-                    cluster_name:    Invoca::Metrics.cluster_name,
-                    service_name:    Invoca::Metrics.service_name,
-                    server_name:     Invoca::Metrics.server_name,
-                    sub_server_name: Invoca::Metrics.sub_server_name)
+        def metrics(statsd_host:     Invoca::Metrics.default_client_config[:statsd_host],
+                    statsd_port:     Invoca::Metrics.default_client_config[:statsd_port],
+                    cluster_name:    Invoca::Metrics.default_client_config[:cluster_name],
+                    service_name:    Invoca::Metrics.default_client_config[:service_name],
+                    server_name:     Invoca::Metrics.default_client_config[:server_name],
+                    sub_server_name: Invoca::Metrics.default_client_config[:sub_server_name])
           new(statsd_host || Client::STATSD_DEFAULT_HOSTNAME,
               statsd_port || Client::STATSD_DEFAULT_PORT,
               cluster_name,

--- a/test/unit/invoca/metrics/metrics_client_test.rb
+++ b/test/unit/invoca/metrics/metrics_client_test.rb
@@ -39,6 +39,23 @@ describe Invoca::Metrics::Client do
       assert_equal 1234,         metrics_client.port
     end
 
+    should "properly construct with configured statsd config for default_config_key" do
+      stub_metrics(server_name:        "prod-fe1",
+                   service_name:       "unicorn",
+                   statsd_host:        "127.0.0.1",
+                   statsd_port:        443,
+                   sub_server_name:    "sub_server_1",
+                   config:             { deploy_group: { server_name: "primary", statsd_host: "128.0.0.2", statsd_port: 3001 } },
+                   default_config_key: :deploy_group)
+
+      metrics_client = Invoca::Metrics::Client.metrics
+
+      assert_equal "128.0.0.2",    metrics_client.hostname
+      assert_equal 3001,           metrics_client.port
+      assert_equal "primary",      metrics_client.server_label
+      assert_equal "sub_server_1", metrics_client.sub_server_name
+    end
+
     should "construct with given args along with default args" do
       Invoca::Metrics.statsd_host = "127.0.0.10"
       Invoca::Metrics.statsd_port = 1234


### PR DESCRIPTION
I noticed I forgot to make this change and so the few places that were accessing the metrics client via `Invoca::Metrics::Client.metrics` without giving parameters were using the global default values instead of the default values based on the `default_config_key`