### PR TITLE
TECH-3939 capture number test metrics -- add in the ability to return…

### DIFF
--- a/lib/invoca/metrics/client.rb
+++ b/lib/invoca/metrics/client.rb
@@ -56,14 +56,14 @@ module Invoca
         end
       end
 
-      def timer(name, milliseconds = nil, &block)
+      def timer(name, milliseconds = nil, return_timing: false, &block)
         name.present? or raise ArgumentError, "Must specify a metric name."
         (!milliseconds.nil? ^ block_given?) or raise ArgumentError, "Must pass exactly one of milliseconds or block."
         name_and_type = [name, "timer", @server_label].join(STATSD_METRICS_SEPARATOR)
 
         if milliseconds.nil?
-          result, _block_time = time(name_and_type, &block)
-          result
+          result, block_time = time(name_and_type, &block)
+          return_timing ? [result, block_time] : result
         else
           timing(name_and_type, milliseconds)
         end

--- a/lib/invoca/metrics/version.rb
+++ b/lib/invoca/metrics/version.rb
@@ -2,6 +2,6 @@
 
 module Invoca
   module Metrics
-    VERSION = "1.4.0"
+    VERSION = "1.5.0"
   end
 end

--- a/test/unit/invoca/metrics/metrics_client_test.rb
+++ b/test/unit/invoca/metrics/metrics_client_test.rb
@@ -230,6 +230,18 @@ describe Invoca::Metrics::Client do
         @metrics_client.timer("unicorn.test_metric.prod-fe1") { 1 + 1 }
       end
 
+      should "return the value from the block" do
+        assert_equal 2, @metrics_client.timer("unicorn.test_metric.prod-fe1") { 1 + 1 }
+      end
+
+      should "return both the value from the block and the timing if specified" do
+        stub(@metrics_client).time { [2, 5000] }
+        result_from_block, timing = @metrics_client.timer("unicorn.test_metric.prod-fe1", return_timing: true) { 1 + 1 }
+
+        assert_equal 2, result_from_block
+        assert_equal 5000, timing
+      end
+
       [nil, ''].each do |value|
         should "fail if metric name is #{value.inspect}" do
           assert_raises(ArgumentError, /Must specify a metric name/) do


### PR DESCRIPTION
… both the timing and the block value