### PR TITLE
Tech 5012 invoca metrics gaugecache should never call sleep 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.2] - 2020-11-09
+### Added
+- Bug Fix `Invoca::Metrics::GaugeCache.start_reporting_thread` no longer calls sleep 0 and now has an intermediate rescue on Exception for a reporting thread. 
+
 ## [1.8.1] - 2020-10-01
 ### Added
 - `Invoca::Metrics::StatsdClient` logs the hostname and port when a new socket is created.
@@ -48,6 +52,7 @@ Initial release
 <!-- TODO: Backfill the contents of the initial release -->
 
 
+[1.8.2]: https://github.com/Invoca/invoca-metrics/compare/v1.8.1...v1.8.2
 [1.8.1]: https://github.com/Invoca/invoca-metrics/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/Invoca/invoca-metrics/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/Invoca/invoca-metrics/compare/v1.6.2...v1.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.8.2] - 2020-11-09
 ### Fixed
-- Bug Fix `Invoca::Metrics::GaugeCache.start_reporting_thread` no longer calls sleep 0 and now has an intermediate rescue on Exception for a reporting thread. 
+- Fixed bug in `Invoca::Metrics::GaugeCache.start_reporting_thread` where sleep 0 was causing thread to sleep forever.   
 
 ## [1.8.1] - 2020-10-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.8.2] - 2020-11-09
-### Added
+### Fixed
 - Bug Fix `Invoca::Metrics::GaugeCache.start_reporting_thread` no longer calls sleep 0 and now has an intermediate rescue on Exception for a reporting thread. 
 
 ## [1.8.1] - 2020-10-01

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    invoca-metrics (1.8.1)
+    invoca-metrics (1.8.2)
       activesupport (>= 4.2, < 7)
       statsd-ruby (~> 1.2.1)
 

--- a/lib/invoca/metrics/gauge_cache.rb
+++ b/lib/invoca/metrics/gauge_cache.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support'
-require 'active_support/core_ext'
 
 module Invoca
   module Metrics

--- a/lib/invoca/metrics/gauge_cache.rb
+++ b/lib/invoca/metrics/gauge_cache.rb
@@ -52,8 +52,14 @@ module Invoca
 
       def start_reporting_thread
         Thread.new do
-          reporting_loop
+          reporting_loop_with_rescue
         end
+      end
+
+      def reporting_loop_with_rescue
+        reporting_loop
+      rescue Exception => ex
+        Invoca::Metrics::Client.logger.error("GaugeCache#reporting_loop_with_rescue rescued exception:\n#{ex.class}: #{ex.message}")
       end
 
       def reporting_loop

--- a/lib/invoca/metrics/gauge_cache.rb
+++ b/lib/invoca/metrics/gauge_cache.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'active_support'
+require 'active_support/core_ext'
+
 module Invoca
   module Metrics
     class GaugeCache
@@ -49,11 +52,17 @@ module Invoca
 
       def start_reporting_thread
         Thread.new do
-          next_time = Time.now.to_i
-          loop do
-            next_time = (((next_time + GAUGE_REPORT_INTERVAL + 1) / GAUGE_REPORT_INTERVAL) * GAUGE_REPORT_INTERVAL) - 1
-            report
-            sleep([next_time - Time.now.to_i, 0].max)
+          reporting_loop
+        end
+      end
+
+      def reporting_loop
+        next_time = Time.now.to_i
+        loop do
+          next_time = (((next_time + GAUGE_REPORT_INTERVAL + 1) / GAUGE_REPORT_INTERVAL) * GAUGE_REPORT_INTERVAL) - 1
+          report
+          if (delay = next_time - Time.now.to_i) > 0
+            sleep(delay)
           end
         end
       end

--- a/lib/invoca/metrics/gauge_cache.rb
+++ b/lib/invoca/metrics/gauge_cache.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 module Invoca
   module Metrics
     class GaugeCache

--- a/lib/invoca/metrics/gauge_cache.rb
+++ b/lib/invoca/metrics/gauge_cache.rb
@@ -69,6 +69,8 @@ module Invoca
           report
           if (delay = next_time - Time.now.to_i) > 0
             sleep(delay)
+          else
+            warn("Window to report gauge may have been missed.")
           end
         end
       end

--- a/lib/invoca/metrics/version.rb
+++ b/lib/invoca/metrics/version.rb
@@ -2,6 +2,6 @@
 
 module Invoca
   module Metrics
-    VERSION = "1.8.1"
+    VERSION = "1.8.2"
   end
 end

--- a/spec/unit/invoca/metrics/gauge_cache_spec.rb
+++ b/spec/unit/invoca/metrics/gauge_cache_spec.rb
@@ -133,7 +133,7 @@ describe Invoca::Metrics::GaugeCache do
       Invoca::Metrics::Client.logger = logger
       expect_any_instance_of(described_class).to receive(:start_reporting_thread)
     end
-    
+
     after do
       Invoca::Metrics::Client.logger = nil
     end
@@ -146,10 +146,9 @@ describe Invoca::Metrics::GaugeCache do
       subject.send(:reporting_loop_with_rescue)
     end
   end
-  
 
   describe '#reporting_loop' do
-    subject { described_class.new(statsd_client) } 
+    subject { described_class.new(statsd_client) }
 
     before do
       expect(Time).to receive(:now).and_return(0.0)
@@ -176,7 +175,7 @@ describe Invoca::Metrics::GaugeCache do
       end.to raise_exception(ScriptError, "Done")
     end
 
-    it 'does not sleep for zero' do 
+    it 'does not sleep for zero' do
       expect(Time).to receive(:now).and_return(59.9)
 
       expect(subject).to_not receive(:sleep)

--- a/spec/unit/invoca/metrics/gauge_cache_spec.rb
+++ b/spec/unit/invoca/metrics/gauge_cache_spec.rb
@@ -5,7 +5,6 @@ require 'invoca/metrics/gauge_cache'
 require 'sourcify'
 
 describe Invoca::Metrics::GaugeCache do
-  let(:reporting_period) { 60.0 }
   let(:statsd_client) { double(Invoca::Metrics::StatsdClient) }
 
   describe 'class' do
@@ -149,6 +148,7 @@ describe Invoca::Metrics::GaugeCache do
 
   describe '#reporting_loop' do
     subject { described_class.new(statsd_client) }
+    let(:reporting_period) { 60.0 }
 
     before do
       expect(Time).to receive(:now).and_return(0.0)

--- a/spec/unit/invoca/metrics/gauge_cache_spec.rb
+++ b/spec/unit/invoca/metrics/gauge_cache_spec.rb
@@ -168,6 +168,7 @@ describe Invoca::Metrics::GaugeCache do
       expect(Time).to receive(:now).and_return(60.2)
 
       expect(subject).to_not receive(:sleep)
+      expect(subject).to receive(:warn).with("Window to report gauge may have been missed.")
       catch(:Done) { subject.send(:reporting_loop) }
     end
 
@@ -175,6 +176,7 @@ describe Invoca::Metrics::GaugeCache do
       expect(Time).to receive(:now).and_return(59.9)
 
       expect(subject).to_not receive(:sleep)
+      expect(subject).to receive(:warn).with("Window to report gauge may have been missed.")
       catch(:Done) { subject.send(:reporting_loop) }
     end
   end

--- a/spec/unit/invoca/metrics/gauge_cache_spec.rb
+++ b/spec/unit/invoca/metrics/gauge_cache_spec.rb
@@ -154,34 +154,28 @@ describe Invoca::Metrics::GaugeCache do
       expect(Time).to receive(:now).and_return(0.0)
       expect_any_instance_of(described_class).to receive(:start_reporting_thread)
       expect(subject).to receive(:report)
-      expect(subject).to receive(:report).and_raise(ScriptError, "Done")
+      expect(subject).to receive(:report) { throw :Done } # to break out of loop
     end
 
     it 'sleeps the remainder of the publish period' do
       expect(Time).to receive(:now).and_return(3.2)
 
       expect(subject).to receive(:sleep).with((reporting_period - 3.2).to_i)
-      expect do
-        subject.send(:reporting_loop)
-      end.to raise_exception(ScriptError, "Done")
+      catch(:Done) { subject.send(:reporting_loop) }
     end
 
     it 'does not sleep a negative amount' do
       expect(Time).to receive(:now).and_return(60.2)
 
       expect(subject).to_not receive(:sleep)
-      expect do
-        subject.send(:reporting_loop)
-      end.to raise_exception(ScriptError, "Done")
+      catch(:Done) { subject.send(:reporting_loop) }
     end
 
     it 'does not sleep for zero' do
       expect(Time).to receive(:now).and_return(59.9)
 
       expect(subject).to_not receive(:sleep)
-      expect do
-        subject.send(:reporting_loop)
-      end.to raise_exception(ScriptError, "Done")
+      catch(:Done) { subject.send(:reporting_loop) }
     end
   end
 end

--- a/spec/unit/invoca/metrics/gauge_cache_spec.rb
+++ b/spec/unit/invoca/metrics/gauge_cache_spec.rb
@@ -125,9 +125,32 @@ describe Invoca::Metrics::GaugeCache do
     end
   end
 
-  describe 'publish loop' do
-    subject { described_class.new(statsd_client) } 
+  describe '#reporting_loop_with_rescue' do
+    subject { described_class.new(statsd_client) }
+    let(:logger) { instance_double(::Logger, "logger") }
+
+    before do
+      Invoca::Metrics::Client.logger = logger
+      expect_any_instance_of(described_class).to receive(:start_reporting_thread)
+    end
     
+    after do
+      Invoca::Metrics::Client.logger = nil
+    end
+
+    it 'rescues and logs exceptions' do
+      expect(subject).to receive(:reporting_loop).and_raise(ScriptError, "error!")
+      allow(logger).to receive(:error).with("GaugeCache#reporting_loop_with_rescue rescued exception:\nScriptError: error!")
+      allow(statsd_client).to receive(:batch)
+
+      subject.send(:reporting_loop_with_rescue)
+    end
+  end
+  
+
+  describe '#reporting_loop' do
+    subject { described_class.new(statsd_client) } 
+
     before do
       expect(Time).to receive(:now).and_return(0.0)
       expect_any_instance_of(described_class).to receive(:start_reporting_thread)


### PR DESCRIPTION
[ticket](https://ringrevenue.atlassian.net/browse/TECH-5012)

Added patch on GaugeCache that it should never call sleep 0.