### PR TITLE
no_jira only warn when not using test service_environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'appraisal'
+gem 'invoca-env',                '~> 0.6'
 gem 'pry'
 gem 'rake'
 gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,8 @@ GEM
       tins (~> 1.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    invoca-env (0.6.0)
+      activesupport (>= 4.0, < 7)
     method_source (1.0.0)
     minitest (5.14.2)
     pry (0.13.1)
@@ -73,6 +75,7 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
+  invoca-env (~> 0.6)
   invoca-metrics!
   pry
   rake

--- a/lib/invoca/metrics/gauge_cache.rb
+++ b/lib/invoca/metrics/gauge_cache.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'invoca/env'
+
 module Invoca
   module Metrics
     class GaugeCache
@@ -67,7 +69,7 @@ module Invoca
           if (delay = next_time - Time.now.to_i) > 0
             sleep(delay)
           else
-            warn("Window to report gauge may have been missed.")
+            warn("Window to report gauge may have been missed.") unless Invoca::Env.service_environment == 'test'
           end
         end
       end

--- a/spec/unit/invoca/metrics/gauge_cache_spec.rb
+++ b/spec/unit/invoca/metrics/gauge_cache_spec.rb
@@ -179,5 +179,14 @@ describe Invoca::Metrics::GaugeCache do
       expect(subject).to receive(:warn).with("Window to report gauge may have been missed.")
       catch(:Done) { subject.send(:reporting_loop) }
     end
+
+    it 'does not warn for Invoca::Env.service_environment is test' do
+      expect(Time).to receive(:now).and_return(60.2)
+
+      expect(subject).to_not receive(:sleep)
+      expect(Invoca::Env).to receive(:service_environment).and_return("test")
+      expect(subject).to_not receive(:warn).with("Window to report gauge may have been missed.")
+      catch(:Done) { subject.send(:reporting_loop) }
+    end
   end
 end


### PR DESCRIPTION
Don't warn in `gauge_cache` reporting loop when in `Invoca::Env.service_environment == 'test'`